### PR TITLE
Fix Composite Data

### DIFF
--- a/ir/src/code.rs
+++ b/ir/src/code.rs
@@ -109,6 +109,26 @@ pub enum Instruction {
         Value
     ),
 
+    /// Compute the reference to a index into a reference to an array or tuple
+    RefIndex(
+        /// Destination register for reference to inner data
+        Register,
+        /// Source container reference
+        Register,
+        /// Index
+        Value
+    ),
+
+    /// Compute the reference to a field within a structure
+    RefField(
+        /// Destination register for reference to inner field
+        Register,
+        /// Source structure reference
+        Register,
+        /// Field name
+        Symbol
+    ),
+
     /// Loads the indexed value starting from zero in the referenced array or tuple on the heap
     LoadIndex(
         /// Destination register

--- a/ir/src/code.rs
+++ b/ir/src/code.rs
@@ -231,6 +231,22 @@ pub enum Instruction {
         Type,
         /// Number of elements in the array
         Value
+    ),
+
+    /// Copy data out of a reference onto the stack, making a new stack allocation. Performs a shallow copy
+    CopyToStack(
+        /// Destination register for stack reference
+        Register,
+        /// Reference to copy to the stack
+        Register
+    ),
+
+    /// Copy data out of a reference onto the heap, making a new heap allocation. Performs a shallow copy
+    CopyToHeap(
+        /// Destination register for heap reference
+        Register,
+        /// Reference to copy into the heap
+        Register
     )
 }
 

--- a/ir/src/code.rs
+++ b/ir/src/code.rs
@@ -207,8 +207,24 @@ pub enum Instruction {
 
     /// Allocate a value on the heap of a specified type and put a reference in the destination register
     Alloc(Register, Type),
+
     /// Allocate an array of values on the heap and put an array value reference in the destination register.
     AllocArray(
+        /// Destination register
+        Register,
+        /// Element type
+        Type,
+        /// Number of elements in the array
+        Value
+    ),
+
+    /// Allocate a value on the stack of a specified type and put a reference in the destination register
+    /// The value will be destroyed when the function returns, rendering the reference invalid
+    StackAlloc(Register, Type),
+
+    /// Allocate an array of values on the stack and put an array value reference in the destination register.
+    /// The array will be destroyed when the function returns, rendering the reference invalid
+    StackAllocArray(
         /// Destination register
         Register,
         /// Element type

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -207,7 +207,7 @@ impl<'w> Machine<'w> {
                     Instruction::Return(v) => {
                         log::trace!("return");
                         let rv = self.mem.cur_frame().convert_value(v);
-                        self.mem.stack.pop();
+                        self.mem.pop_stack();
                         return Ok(rv)
                     },
                     Instruction::RefFunc(dest, _) => todo!(),
@@ -222,6 +222,18 @@ impl<'w> Machine<'w> {
                             _ => bail!("invalid count for array alloc")
                         };
                         let nrf = self.mem.alloc_array(r#type, count)?;
+                        self.mem.cur_frame().store(dest, nrf);
+                    },
+                    Instruction::StackAlloc(dest, r#type) => {
+                        let nrf = self.mem.stack_alloc(r#type)?;
+                        self.mem.cur_frame().store(dest, nrf);
+                    },
+                    Instruction::StackAllocArray(dest, r#type, count) => {
+                        let count = match self.mem.cur_frame().convert_value(count) {
+                            Value::Int(Integer { signed: false, data, .. }) => data as usize,
+                            _ => bail!("invalid count for array alloc")
+                        };
+                        let nrf = self.mem.stack_alloc_array(r#type, count)?;
                         self.mem.cur_frame().store(dest, nrf);
                     },
                 }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -6,7 +6,8 @@ pub enum Value {
     Nil, Bool(bool),
     Int(Integer),
     Float(Float),
-    Ref(crate::memory::HeapRef), Array(crate::memory::HeapRef), Fn
+    Ref(crate::memory::Ref),
+    Fn
 }
 
 impl Value {
@@ -17,7 +18,6 @@ impl Value {
             Value::Int(i) => ir::Type::Int { signed: i.signed, width: i.width },
             Value::Float(f) => ir::Type::Float { width: f.width() },
             Value::Ref(v) => v.type_of().clone(),
-            Value::Array(v) => v.type_of().clone(),
             Value::Fn => ir::Type::FnRef(todo!()),
         }
     }

--- a/vm/src/world.rs
+++ b/vm/src/world.rs
@@ -161,6 +161,10 @@ impl World {
         })
     }
 
+    pub fn array_size(&self, el_ty: &ir::Type, count: usize) -> Result<usize> {
+        Ok(std::mem::size_of::<usize>() + self.size_of_type(el_ty)?*count)
+    }
+
     pub fn required_alignment(&self, ty: &ir::Type) -> Result<usize> {
         use ir::Type;
         Ok(match ty {

--- a/vm/src/world.rs
+++ b/vm/src/world.rs
@@ -143,7 +143,7 @@ impl World {
             Type::Bool => 1,
             Type::Int { width, .. } => *width as usize / 8,
             Type::Float { width } => *width as usize / 8,
-            Type::Ref(_) | Type::AbstractRef(_) | Type::Array(_) => std::mem::size_of::<crate::memory::HeapRef>(),
+            Type::Ref(_) | Type::AbstractRef(_) | Type::Array(_) => std::mem::size_of::<crate::memory::Ref>(),
             Type::Tuple(fields) => {
                 let mut size = 0;
                 for ty in fields.iter() {
@@ -153,7 +153,8 @@ impl World {
                 }
                 size
             },
-            Type::User(def_path, params) => self.get_type(def_path).ok_or_else(|| anyhow!("unknown type"))
+            Type::User(def_path, params) => self.get_type(def_path)
+                .ok_or_else(|| anyhow!("unknown type ty={:?}", ty))
                 .and_then(|t| self.size_of_user_type(t, params))?,
             Type::FnRef(_) => 0, //for now not sure what we'll actually store here
             Type::Var(_) => panic!(),

--- a/vm/test_modules/basic_stack_struct.s
+++ b/vm/test_modules/basic_stack_struct.s
@@ -1,0 +1,42 @@
+Module(
+    path: Path([Symbol("basic_stack_struct")]),
+    version: "0.0.1",
+    types: {
+        Symbol("foo"): Product(
+            parameters: [],
+            fields: [
+                (Symbol("a"), Int(signed: false, width: 64)),
+                (Symbol("b"), Int(signed: false, width: 64)),
+                (Symbol("c"), Bool),
+            ]
+        )
+    },
+    interfaces: {},
+    implementations: {},
+    functions: {
+        Symbol("start"): (
+            FunctionSignature(args: [], return_type: Int(width: 64, signed: false)),
+            FnBody(
+                max_registers: 6,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            StackAlloc(Register(0), User(Path([Symbol("basic_stack_struct"), Symbol("foo")]), None)),
+                            StoreField(LiteralInt(Integer(width: 64, signed: false, data: 3)), Register(0), Symbol("a")),
+                            StoreField(LiteralInt(Integer(width: 64, signed: false, data: 9)), Register(0), Symbol("b")),
+                            StoreField(LiteralBool(true), Register(0), Symbol("c")),
+                            LoadField(Register(1), Register(0), Symbol("a")),
+                            LoadField(Register(2), Register(0), Symbol("b")),
+                            LoadField(Register(3), Register(0), Symbol("c")),
+                            BinaryOp(Add, Register(4), Reg(Register(1)), Reg(Register(2))),
+                            BinaryOp(Sub, Register(5), Reg(Register(4)), LiteralInt(Integer(width: 64, signed: false, data: 12))),
+                            Return(/* LiteralInt(Integer(width: 64, signed: false, data: 0)) */ Reg(Register(5)))
+                        ],
+                        next_block: 0
+                    )
+                ]
+            )
+        )
+    },
+    imports: []
+)

--- a/vm/test_modules/basic_struct.s
+++ b/vm/test_modules/basic_struct.s
@@ -8,7 +8,6 @@ Module(
                 (Symbol("a"), Int(signed: false, width: 64)),
                 (Symbol("b"), Int(signed: false, width: 64)),
                 (Symbol("c"), Bool),
-                (Symbol("q"), Ref(Int(signed: false, width: 64))),
             ]
         )
     },

--- a/vm/test_modules/copy.s
+++ b/vm/test_modules/copy.s
@@ -1,0 +1,44 @@
+Module(
+    path: Path([Symbol("copy")]),
+    version: "0.0.1",
+    types: {
+        Symbol("foo"): Product(
+            parameters: [],
+            fields: [
+                (Symbol("a"), Int(signed: false, width: 64)),
+                (Symbol("b"), Int(signed: false, width: 64)),
+            ]
+        )
+    },
+    interfaces: {},
+    implementations: {},
+    functions: {
+        Symbol("start"): (
+            FunctionSignature(args: [], return_type: Int(width: 64, signed: false)),
+            FnBody(
+                max_registers: 7,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            Alloc(Register(0), User(Path([Symbol("copy"), Symbol("foo")]), None)),
+                            StoreField(LiteralInt(Integer(width: 64, signed: false, data: 21)), Register(0), Symbol("a")),
+                            StoreField(LiteralInt(Integer(width: 64, signed: false, data: 36)), Register(0), Symbol("b")),
+
+                            CopyToStack(Register(1), Register(0)),
+                            CopyToHeap(Register(2), Register(1)),
+
+                            LoadField(Register(3), Register(2), Symbol("a")),
+                            LoadField(Register(4), Register(2), Symbol("b")),
+                            BinaryOp(Add, Register(5), Reg(Register(3)), Reg(Register(4))),
+                            BinaryOp(Sub, Register(6), Reg(Register(5)), LiteralInt(Integer(width:
+                            64, signed: false, data: 57))),
+                            Return(Reg(Register(6)))
+                        ],
+                        next_block: 0
+                    )
+                ]
+            )
+        )
+    },
+    imports: []
+)

--- a/vm/test_modules/ref_to_inner_element.s
+++ b/vm/test_modules/ref_to_inner_element.s
@@ -1,0 +1,60 @@
+Module(
+    path: Path([Symbol("ref_to_inner_element")]),
+    version: "0.0.1",
+    types: {},
+    interfaces: {},
+    implementations: {},
+    functions: {
+        Symbol("incr"): (
+            FunctionSignature(args: [(Ref(Int(width: 64, signed: false)), Symbol("p"))], return_type: Unit),
+            FnBody(
+                max_registers: 3,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            LoadRef(Register(1), Register(0)),
+                            BinaryOp(Add, Register(2), Reg(Register(1)),
+                                LiteralInt(Integer(width: 64, signed: false, data: 1))),
+                            StoreRef(Register(0), Reg(Register(2))),
+                            Return(LiteralUnit)
+                        ],
+                        next_block: 999
+                    )
+                ]
+            )
+        ),
+        Symbol("start"): (
+            FunctionSignature(args: [], return_type: Int(width: 64, signed: false)),
+            FnBody(
+                max_registers: 5,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            AllocArray(Register(0), Int(width: 64, signed: false),
+                                LiteralInt(Integer(width: 64, signed: false, data: 3))),
+                            StoreIndex(Register(0),
+                                LiteralInt(Integer(width: 64, signed: false, data: 0)),
+                                LiteralInt(Integer(width: 64, signed: false,  data: 15))),
+                            StoreIndex(Register(0),
+                                LiteralInt(Integer(width: 64, signed: false, data: 2)),
+                                LiteralInt(Integer(width: 64, signed: false,  data: 9))),
+                            StoreIndex(Register(0),
+                                LiteralInt(Integer(width: 64, signed: false, data: 1)),
+                                LiteralInt(Integer(width: 64, signed: false,  data: 6))),
+                            RefIndex(Register(1), Register(0), LiteralInt(Integer(width: 64, signed: false, data: 1))),
+                            Call(Register(2), Path([Symbol("ref_to_inner_element"), Symbol("incr")]),
+                            [Reg(Register(1))]),
+                            LoadIndex(Register(3), Register(0), LiteralInt(Integer(width: 64,
+                                signed: false, data: 1))),
+                            BinaryOp(Sub, Register(4), Reg(Register(3)),
+                                LiteralInt(Integer(width: 64, signed: false, data: 10))),
+                            Return(Reg(Register(4)))
+                       ],
+                        next_block: 0
+                    )
+                ]
+            )
+        )
+    },
+    imports: []
+)

--- a/vm/test_modules/ref_to_inner_field.s
+++ b/vm/test_modules/ref_to_inner_field.s
@@ -1,0 +1,59 @@
+Module(
+    path: Path([Symbol("ref_to_inner_field")]),
+    version: "0.0.1",
+    types: {
+        Symbol("foo"): Product(
+            parameters: [],
+            fields: [
+                (Symbol("a"), Int(signed: false, width: 64)),
+                (Symbol("b"), Int(signed: false, width: 64)),
+            ]
+        )
+    },
+    interfaces: {},
+    implementations: {},
+    functions: {
+        Symbol("incr"): (
+            FunctionSignature(args: [(Ref(Int(width: 64, signed: false)), Symbol("p"))], return_type: Unit),
+            FnBody(
+                max_registers: 3,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            LoadRef(Register(1), Register(0)),
+                            BinaryOp(Add, Register(2), Reg(Register(1)),
+                                LiteralInt(Integer(width: 64, signed: false, data: 1))),
+                            StoreRef(Register(0), Reg(Register(2))),
+                            Return(LiteralUnit)
+                        ],
+                        next_block: 999
+                    )
+                ]
+            )
+        ),
+        Symbol("start"): (
+            FunctionSignature(args: [], return_type: Int(width: 64, signed: false)),
+            FnBody(
+                max_registers: 5,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            Alloc(Register(0), User(Path([Symbol("ref_to_inner_field"), Symbol("foo")]), None)),
+                            StoreField(LiteralInt(Integer(width: 64, signed: false, data: 3)), Register(0), Symbol("a")),
+                            StoreField(LiteralInt(Integer(width: 64, signed: false, data: 9)), Register(0), Symbol("b")),
+                            RefField(Register(1), Register(0), Symbol("b")),
+                            Call(Register(2), Path([Symbol("ref_to_inner_field"), Symbol("incr")]),
+                            [Reg(Register(1))]),
+                            LoadField(Register(3), Register(0), Symbol("b")),
+                            BinaryOp(Sub, Register(4), Reg(Register(3)),
+                                LiteralInt(Integer(width: 64, signed: false, data: 10))),
+                            Return(Reg(Register(4)))
+                       ],
+                        next_block: 0
+                    )
+                ]
+            )
+        )
+    },
+    imports: []
+)

--- a/vm/test_modules/run-release.sh
+++ b/vm/test_modules/run-release.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cargo build --workspace --release
+ASM=../../target/release/asm
+VM=../../target/release/vm
+
+# assemble test modules
+echo "==== Assembling test modules ===="
+mkdir -p /tmp/oxlr_test_modules
+find -type f -name "*.s" | xargs -I {} -- $ASM {} /tmp/oxlr_test_modules
+echo
+
+# run test modules
+echo "==== Running test modules ======="
+export OXLR_MODULE_PATH=/tmp/oxlr_test_modules
+export RUST_LOG=info
+find -type f -name "*.s" -printf "%f\n" | cut -d '.' -f -1 \
+    | xargs -n 1 -- $VM

--- a/vm/test_modules/stack_array_alloc.s
+++ b/vm/test_modules/stack_array_alloc.s
@@ -1,0 +1,39 @@
+Module(
+    path: Path([Symbol("stack_array_alloc")]),
+    version: "0.0.1",
+    types: {},
+    interfaces: {},
+    implementations: {},
+    functions: {
+        Symbol("start"): (
+            FunctionSignature(args: [], return_type: Int(width: 64, signed: false)),
+            FnBody(
+                max_registers: 6,
+                blocks: [
+                    BasicBlock(
+                        instrs: [
+                            StackAllocArray(Register(0), Int(width: 64, signed: false), LiteralInt(Integer(width: 64, signed: false, data: 3))),
+                            StoreIndex(Register(0),
+                                LiteralInt(Integer(width: 64, signed: false, data: 0)),
+                                LiteralInt(Integer(width: 64, signed: false,  data: 15))),
+                            StoreIndex(Register(0),
+                                LiteralInt(Integer(width: 64, signed: false, data: 2)),
+                                LiteralInt(Integer(width: 64, signed: false,  data: 9))),
+                            StoreIndex(Register(0),
+                                LiteralInt(Integer(width: 64, signed: false, data: 1)),
+                                LiteralInt(Integer(width: 64, signed: false,  data: 6))),
+                            LoadIndex(Register(1), Register(0), LiteralInt(Integer(width: 64, signed: false, data: 1))),
+                            LoadIndex(Register(2), Register(0), LiteralInt(Integer(width: 64, signed: false, data: 2))),
+                            LoadIndex(Register(3), Register(0), LiteralInt(Integer(width: 64, signed: false, data: 0))),
+                            BinaryOp(Add, Register(4), Reg(Register(1)), Reg(Register(2))),
+                            BinaryOp(Sub, Register(5), Reg(Register(4)), Reg(Register(3))),
+                            Return(Reg(Register(5)))
+                        ],
+                        next_block: 99
+                    )
+                ]
+            )
+        )
+    },
+    imports: []
+)


### PR DESCRIPTION
Introduces new instructions `RefField`, `RefIndex`, `CopyToStack` and `CopyToHeap`. These enable composite data on the stack interfaced through references like the heap, and getting references to inner parts of data. The VM now uses a consistent `Ref` type for all references to data throughout, for both the stack and heap. 